### PR TITLE
kutty-bootstrap: Add components: Alert and Card

### DIFF
--- a/kutty/bootstrap/__init__.py
+++ b/kutty/bootstrap/__init__.py
@@ -1,0 +1,1 @@
+from .alert import Alert

--- a/kutty/bootstrap/__init__.py
+++ b/kutty/bootstrap/__init__.py
@@ -1,1 +1,2 @@
 from .alert import Alert
+from .card import Card

--- a/kutty/bootstrap/alert.py
+++ b/kutty/bootstrap/alert.py
@@ -1,0 +1,84 @@
+"""The Alert component.
+
+Sample usage:
+
+```
+from kutty.bootstrap import Alert
+
+alert = Alert(dismissible=True)
+alert.add("Congrats! You've passed the test.")
+```
+
+With links:
+
+```
+from kutty import Link
+from kutty.bootstrap import Alert
+
+alert = Alert(dismissible=False)
+alert.add([
+    "A simple primary alert with ",
+    Link("an example link", href="/link"),
+    ". Give it a click if you like."
+])
+```
+
+With heading:
+
+```
+from kutty import Link
+from kutty.bootstrap import Alert
+
+alert = Alert()
+alert.add_heading("Well done")
+alert.add("You have solved the assignment successfully.")
+```
+"""
+from kutty import Link, html
+from .base import BootstrapElement
+
+
+class Alert(BootstrapElement):
+    def __init__(self, dismissible=True):
+        self._dismissible = dismissible
+        self.content = []
+
+    @property
+    def dismissible(self):
+        # read-only
+        return self._dismissible
+
+    def add(self, element):
+        # TODO: This needs to be there, but needs changing in HTMLElement
+        # if isinstance(element, Link):
+        #     element.add_class("alert-link")
+        return self.content.append(element)
+
+    def add_heading(self, content):
+        return self.add(
+            html.h4(class_="alert-heading").add(content)
+        )
+
+    def render(self):
+        classes = ["alert"]
+        if self.dismissible:
+            classes += self.get_dismissible_classes()
+
+        node = html.div(class_=" ".join(classes), role="alert")
+        for element in self.content:
+            node << element
+
+        if self.dismissible:
+            node << self.get_dismiss_button()
+
+        return node.render()
+
+    def get_dismissible_classes(self):
+        return ["alert-dismissible", "fade", "show"]
+
+    def get_dismiss_button(self):
+        button = html.button(type="button", class_="close")
+        button.attrs["data-dismiss"] = "alert"
+
+        button << html.span("&times;")
+        return button

--- a/kutty/bootstrap/base.py
+++ b/kutty/bootstrap/base.py
@@ -1,5 +1,5 @@
 from kutty import html
 
 
-class BootstrapElement(html.Element):
+class BootstrapElement(html.HTMLElement):
     pass

--- a/kutty/bootstrap/base.py
+++ b/kutty/bootstrap/base.py
@@ -1,0 +1,5 @@
+from kutty import html
+
+
+class BootstrapElement(html.Element):
+    pass

--- a/kutty/bootstrap/card.py
+++ b/kutty/bootstrap/card.py
@@ -1,0 +1,287 @@
+"""Bootstrap Card component.
+
+There is a `Card` low-level component that doesn't have anything by itself but
+needs to be populated by hand with `.add_body()`, `.add_header()`,
+`.add_footer()`, in addition to `.add()`.
+
+This module also exposes the higher-level components built on top of `Card`.
+It is recommended to use them directly.
+Higher-level components: `SimpleCard`
+
+Example usage:
+
+```python
+from kutty.bootstrap import SimpleCard
+
+card = SimpleCard(
+    title="Foo", subtitle="More about foo", text="Foo is spam, ham and eggs."
+)
+card.body << Link("Go somewhere", href="#")
+```
+
+Header and footer elements are automatically added, and can be populated with
+`<<` or with text during initialization.
+
+```python
+from kutty.bootstrap import SimpleCard
+
+# either like this:
+card = SimpleCard(header="Featured")
+
+# or like this:
+card = SimpleCard()
+card.header << "Featured"
+```
+
+Footer can be accessed analogously with `.footer`.
+
+Content can be added to the "top" and "bottom" of the card by adding to
+`card.top` and `card.bottom`. `card.top` is (by default) a `div` between
+the header and body, and `card.bottom` is (by default) a `div` between
+the body and footer.
+
+```python
+from kutty import Image
+from kutty.bootstrap import SimpleCard
+
+card = SimpleCard()
+card.top << Image("https://example.com/image.jpeg")
+```
+
+Additionally, any image added to `card.top` will be injected with the class
+`card-img-top`. This gives the image rounded top corners. The behaviour is
+analogous when an image is added to the bottom of the card, the class added
+is `card-img-bottom`.
+
+For advanced usage, `Card` must be used instead of `SimpleCard`. This allows
+more flexibility with `card.add_header`, `card.add_footer`, `card.add_body`,
+and `card.add`.
+
+For example, to create a list group inside an empty card, you can write:
+
+```python
+from kutty import html as h
+from kutty.bootstrap import SimpleCard
+
+card = Card(
+    h.ul(class_="list-group list-group-flush")
+      .add(h.li(class_="list-group-item", _content="An item"))
+      .add(h.li(class_="list-group-item", _content="A second item"))
+      .add(h.li(class_="list-group-item", _content="A third item"))
+)
+```
+"""
+
+from kutty import html, Link
+from .base import BootstrapElement
+
+
+class Card(BootstrapElement):
+    TAG = "div"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_class("card")
+
+    def add_header(self, *args, **kwargs):
+        element = Header(*args, **kwargs)
+        self.add(element)
+        return element
+
+    def add_body(self, *args, **kwargs):
+        element = Body(*args, **kwargs)
+        self.add(element)
+        return element
+
+    def add_footer(self, *args, **kwargs):
+        element = Footer(*args, **kwargs)
+        self.add(element)
+        return element
+
+class Header(BootstrapElement):
+    TAG = "div"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_class("card-header")
+
+class Body(BootstrapElement):
+    TAG = "div"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_class("card-body")
+
+    def add_title(self, content):
+        if is_heading_element(content):
+            element = content
+        else:
+            element = html.h5(content)
+        element.add_class("card-title")
+        super().add(element)
+        return element
+
+    def add_subtitle(self, content):
+        if is_heading_element(content):
+            element = content
+        else:
+            element = html.h6(content)
+        element.add_class("card-subtitle text-muted")
+        super().add(element)
+        return element
+
+    def add_text(self, content):
+        if is_paragraph_element(content):
+            element = content
+        else:
+            element = html.p(content)
+        element.add_class("card-text")
+        super().add(element)
+        return element
+
+    def add_link(self, content):
+        if is_link_element(content):
+            element = content
+        else:
+            element = Link(content)
+        element.add_class("card-link")
+        super().add(element)
+        return element
+
+class Footer(BootstrapElement):
+    TAG = "div"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.add_class("card-footer")
+
+class DefaultElement(html.HTMLElement):
+    def __init__(
+            self, *args,
+            empty_condition=lambda self: not self.children, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.empty_condition = empty_condition
+
+    def render(self):
+        if self.empty_condition(self):
+            return ""
+        else:
+            return super().render()
+
+class SimpleBody(Body):
+    def __init__(self, *args, title=None, subtitle=None, text=None, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        self.title = self.add_title(title)
+        self.subtitle = self.add_subtitle(subtitle)
+        self.text = self.add_text(text)
+
+    def add_title(self, title=None):
+        if is_heading_element(title) or is_text(title):
+            element = super().add_title(title)
+        else:
+            element = DefaultElement(_tag="h5", class_="card-title")
+            self.add(element)
+            if title is not None:
+                element << title
+        return element
+
+    def add_subtitle(self, subtitle=None):
+        if is_heading_element(subtitle) or is_text(subtitle):
+            element = super().add_subtitle(subtitle)
+        else:
+            element = DefaultElement(_tag="h6", class_="card-subtitle text-muted")
+            self.add(element)
+            if subtitle is not None:
+                element << subtitle
+        return element
+
+    def add_text(self, text=None):
+        if is_paragraph_element(text) or is_text(text):
+            element = super().add_text(text)
+        else:
+            element = DefaultElement(_tag="p", class_="card-text")
+            self.add(element)
+            if text is not None:
+                element << text
+        return element
+
+    def add(self, element):
+        if is_link_element(element):
+            super().add_link(element)
+            return self  # add should return self
+        else:
+            return super().add(element)
+
+class Top(BootstrapElement):
+    TAG = "div"
+
+    def add(self, element):
+        if is_image_element(element):
+            element.add_class("card-img-top")
+        return super().add(element)
+
+class Bottom(BootstrapElement):
+    TAG = "div"
+
+    def add(self, element):
+        if is_image_element(element):
+            element.add_class("card-img-bottom")
+        return super().add(element)
+
+class SimpleCard(Card):
+    def __init__(
+            self,
+            *args,
+            header=None, top=None,
+            body=None,
+            bottom=None, footer=None,
+            title=None, subtitle=None, text=None,
+            **kwargs):
+        super().__init__(*args, **kwargs)
+        self.header = Header(header)
+        self.top = Top(top)
+        self.body = SimpleBody(body) if body else \
+            SimpleBody(title=title, subtitle=subtitle, text=text) if title or subtitle or text else \
+            SimpleBody()
+        self.bottom = Bottom(bottom)
+        self.footer = Footer(footer)
+
+    def get_children(self):
+        elements = [self.header, self.top, self.body, self.bottom,
+                    *self.children, self.footer]
+        for element in elements:
+            if not self._is_empty_component(element):
+                yield element
+
+    def render(self):
+        attrs = "".join(" " + self._render_attr(name, value) for name, value in self.attrs.items())
+        children = self.get_children()
+        content = "".join(c.render() for c in children)
+        return f"<{self.TAG}{attrs}>{content}</{self.TAG}>"
+
+    def _is_empty_component(self, thing):
+        components = {self.header, self.top, self.body,
+                      self.bottom, self.footer}
+        return thing in components \
+            and isinstance(thing, html.HTMLElement) \
+            and not thing.children
+
+def is_heading_element(thing):
+    return isinstance(thing, html.HTMLElement) and \
+            thing.TAG in {"h1", "h2", "h3", "h4", "h5", "h6"}
+
+def is_link_element(thing):
+    return isinstance(thing, html.HTMLElement) and \
+            thing.TAG == "a"
+
+def is_image_element(thing):
+    return isinstance(thing, html.HTMLElement) and \
+            thing.TAG == "img"
+
+def is_paragraph_element(thing):
+    return isinstance(thing, html.HTMLElement) and \
+            thing.TAG == "p"
+
+def is_text(thing):
+    return isinstance(thing, str) or isinstance(thing, html.Text)

--- a/kutty/components/image.py
+++ b/kutty/components/image.py
@@ -11,5 +11,5 @@ print(img)
 
 from .. import html
 
-def Image(src, **kwargs):
-    return html.img(src, **kwargs)
+def Image(src, *args, **kwargs):
+    return html.img(*args, src=src, **kwargs)

--- a/tests/bootstrap/test_alert.yml
+++ b/tests/bootstrap/test_alert.yml
@@ -1,0 +1,61 @@
+# name: test alert with link
+# code: |
+#   from kutty.bootstrap import Alert
+# 
+#   alert = Alert(dismissible=False)
+#   alert.add([
+#       "A simple primary alert with ",
+#       Link("an example link", href="/link"),
+#       ". Give it a click if you like."
+#   ])
+# html: |
+#   <div class="alert" role="alert">
+#     A simple primary alert with <a href="/link" class="alert-link">an example link</a>. Give it a click if you like.
+#   </div>
+# ---
+name: test simple alert
+code: |
+  from kutty.bootstrap import Alert
+
+  alert = Alert(dismissible=False)
+  alert.add("A simple alert.")
+
+  result = alert.render()
+html: |
+  <div class="alert" role="alert">
+    A simple alert.
+  </div>
+---
+name: test simple dismissible alert
+code: |
+  from kutty.bootstrap import Alert
+
+  alert = Alert()
+  alert.add("This is a dismissible alert.")
+
+  result = alert.render()
+html: |
+  <div class="alert alert-dismissible fade show" role="alert">
+    This is a dismissible alert.
+    <button type="button" class="close" data-dismiss="alert">
+      <span>&times;</span>
+    </button>
+  </div>
+---
+name: test simple dismissible alert with heading
+code: |
+  from kutty.bootstrap import Alert
+
+  alert = Alert()
+  alert.add_heading("Well done")
+  alert.add("You have solved the assignment successfully.")
+
+  result = alert.render()
+html: |
+  <div class="alert alert-dismissible fade show" role="alert">
+    <h4 class="alert-heading">Well done</h4>
+    You have solved the assignment successfully.
+    <button type="button" class="close" data-dismiss="alert">
+      <span>&times;</span>
+    </button>
+  </div>

--- a/tests/bootstrap/test_card.yml
+++ b/tests/bootstrap/test_card.yml
@@ -1,0 +1,148 @@
+name: test simple card
+code: |
+  from kutty import Link
+  from kutty.bootstrap import SimpleCard
+
+  card = SimpleCard()
+  card.body.text << "Card text"
+  card.body.title << "Card title"
+  card.body.subtitle << "Card subtitle"
+  card.body << Link("foo", href="/foo")
+  card.footer << "Card footer"
+
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">
+        Card title
+      </h5>
+      <h6 class="card-subtitle text-muted">
+        Card subtitle
+      </h6>
+      <p class="card-text">
+        Card text
+      </p>
+      <a href="/foo" class="card-link">foo</a>
+    </div>
+    <div class="card-footer">
+      Card footer
+    </div>
+  </div>
+---
+name: test simple card with top image
+code: |
+  from kutty import Image, Link
+  from kutty.bootstrap import SimpleCard
+
+  card = SimpleCard()
+  card.top << Image("https://example.com/image.jpg")
+  card.body << Link("spam", href="/spam")
+
+  result = card.render()
+html: |
+  <div class="card">
+    <div><img src="https://example.com/image.jpg" class="card-img-top"></div>
+    <div class="card-body">
+      <a href="/spam" class="card-link">spam</a>
+    </div>
+  </div>
+---
+name: test simple card with title only
+code: |
+  from kutty.bootstrap import SimpleCard
+
+  card = SimpleCard(title="Hello world!")
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">Hello world!</h5>
+    </div>
+  </div>
+---
+name: test simple card with subtitle only
+code: |
+  from kutty.bootstrap import SimpleCard
+
+  card = SimpleCard(subtitle="Something about foo")
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-body">
+      <h6 class="card-subtitle">Something about foo</h6>
+    </div>
+  </div>
+---
+name: test card with list group
+code: |
+  from kutty import html as h
+  from kutty.bootstrap import Card
+
+  card = Card(
+    h.ul(class_="list-group list-group-flush")
+      .add(h.li(class_="list-group-item", _content="An item"))
+      .add(h.li(class_="list-group-item", _content="A second item"))
+      .add(h.li(class_="list-group-item", _content="A third item"))
+  )
+  result = card.render()
+html: |
+  <div class="card">
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">An item</li>
+      <li class="list-group-item">A second item</li>
+      <li class="list-group-item">A third item</li>
+    </ul>
+  </div>
+---
+name: test card with list group, header and footer
+code: |
+  from kutty import html as h
+  from kutty.bootstrap import Card
+
+  card = Card()
+  card.add_header("Featured")
+  card.add(
+    h.ul(class_="list-group list-group-flush")
+      .add(h.li(class_="list-group-item", _content="An item"))
+      .add(h.li(class_="list-group-item", _content="A second item"))
+      .add(h.li(class_="list-group-item", _content="A third item"))
+  )
+  card.add_footer("Card footer")
+
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-header">
+      Featured
+    </div>
+    <ul class="list-group list-group-flush">
+      <li class="list-group-item">An item</li>
+      <li class="list-group-item">A second item</li>
+      <li class="list-group-item">A third item</li>
+    </ul>
+    <div class="card-footer">
+      Card footer
+    </div>
+  </div>
+---
+name: test card with link in body
+code: |
+  from kutty import Link
+  from kutty.bootstrap import SimpleCard
+
+  card = SimpleCard(title="Card title", subtitle="Card subtitle", text="Card text")
+  card.body << Link("Card link", href="/foo")
+  card.body << Link("Another link", href="/bar")
+
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">Card title</h5>
+      <h6 class="card-subtitle text-muted">Card subtitle</h6>
+      <p class="card-text">Card text</p>
+      <a href="/foo" class="card-link">Card link</a>
+      <a href="/bar" class="card-link">Another link</a>
+    </div>
+  </div>

--- a/tests/bootstrap/test_card.yml
+++ b/tests/bootstrap/test_card.yml
@@ -1,76 +1,112 @@
-name: test simple card
+name: test card with title, subtitle, text as kwargs, and a link
 code: |
-  from kutty import Link
-  from kutty.bootstrap import SimpleCard
+  from kutty.bootstrap import Card
 
-  card = SimpleCard()
-  card.body.text << "Card text"
-  card.body.title << "Card title"
-  card.body.subtitle << "Card subtitle"
-  card.body << Link("foo", href="/foo")
-  card.footer << "Card footer"
+  card = Card(
+      title="Foo", subtitle="More about foo", text="Foo is spam, ham and eggs."
+  )
+  card.body.add_link("Go somewhere", "#")
 
   result = card.render()
 html: |
   <div class="card">
     <div class="card-body">
       <h5 class="card-title">
-        Card title
+        Foo
       </h5>
       <h6 class="card-subtitle text-muted">
-        Card subtitle
+        More about foo
       </h6>
       <p class="card-text">
-        Card text
+        Foo is spam, ham and eggs.
       </p>
-      <a href="/foo" class="card-link">foo</a>
+      <a class="card-link" href="#">
+        Go somewhere
+      </a>
+    </div>
+  </div>
+---
+name: test card with title, subtitle, text from methods, and a link
+code: |
+  from kutty.bootstrap import Card
+
+  card = Card()
+  card.body.add_title("Foo")
+  card.body.add_subtitle("More about foo")
+  card.body.add_text("Foo is spam, ham and eggs.")
+  card.body.add_link("Go somewhere", "#")
+
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-body">
+      <h5 class="card-title">
+        Foo
+      </h5>
+      <h6 class="card-subtitle text-muted">
+        More about foo
+      </h6>
+      <p class="card-text">
+        Foo is spam, ham and eggs.
+      </p>
+      <a class="card-link" href="#">
+        Go somewhere
+      </a>
+    </div>
+  </div>
+---
+name: test card with top image
+code: |
+  from kutty.bootstrap import Card
+
+  card = Card()
+  card.add_top_image("/foo.jpeg", alt="Foo picture")
+  card.add_body(title="Hello, world!")
+
+  result = card.render()
+html: |
+  <div class="card">
+    <img class="card-img-top" src="/foo.jpeg" alt="Foo picture" />
+    <div class="card-body">
+      <h5 class="card-title">Hello, world!</h5>
+    </div>
+  </div>
+--- 
+name: test card with top image with composed
+code: |
+  from kutty.bootstrap import Card
+  from kutty.bootstrap.card import CardImageTop, CardBody, CardTitle
+
+  card = Card(
+    CardImageTop("/foo.jpeg", alt="Foo picture"),
+    CardBody(
+      CardTitle("Hello, world!")
+    )
+  )
+
+  result = card.render()
+html: |
+  <div class="card">
+    <img class="card-img-top" src="/foo.jpeg" alt="Foo picture" />
+    <div class="card-body">
+      <h5 class="card-title">Hello, world!</h5>
+    </div>
+  </div>
+---
+name: test card with footer
+code: |
+  from kutty.bootstrap import Card
+
+  card = Card(text="Hello, world!", footer="Card footer")
+
+  result = card.render()
+html: |
+  <div class="card">
+    <div class="card-body">
+      <p class="card-text">Hello, world!</p>
     </div>
     <div class="card-footer">
       Card footer
-    </div>
-  </div>
----
-name: test simple card with top image
-code: |
-  from kutty import Image, Link
-  from kutty.bootstrap import SimpleCard
-
-  card = SimpleCard()
-  card.top << Image("https://example.com/image.jpg")
-  card.body << Link("spam", href="/spam")
-
-  result = card.render()
-html: |
-  <div class="card">
-    <div><img src="https://example.com/image.jpg" class="card-img-top"></div>
-    <div class="card-body">
-      <a href="/spam" class="card-link">spam</a>
-    </div>
-  </div>
----
-name: test simple card with title only
-code: |
-  from kutty.bootstrap import SimpleCard
-
-  card = SimpleCard(title="Hello world!")
-  result = card.render()
-html: |
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">Hello world!</h5>
-    </div>
-  </div>
----
-name: test simple card with subtitle only
-code: |
-  from kutty.bootstrap import SimpleCard
-
-  card = SimpleCard(subtitle="Something about foo")
-  result = card.render()
-html: |
-  <div class="card">
-    <div class="card-body">
-      <h6 class="card-subtitle">Something about foo</h6>
     </div>
   </div>
 ---
@@ -79,11 +115,15 @@ code: |
   from kutty import html as h
   from kutty.bootstrap import Card
 
+  li = h.new_element(h.li, class_="list-group-item")
+
   card = Card(
-    h.ul(class_="list-group list-group-flush")
-      .add(h.li(class_="list-group-item", _content="An item"))
-      .add(h.li(class_="list-group-item", _content="A second item"))
-      .add(h.li(class_="list-group-item", _content="A third item"))
+    h.ul(
+      {"class": "list-group list-group-flush"},
+      li("An item"),
+      li("A second item"),
+      li("A third item"),
+    )
   )
   result = card.render()
 html: |
@@ -93,56 +133,4 @@ html: |
       <li class="list-group-item">A second item</li>
       <li class="list-group-item">A third item</li>
     </ul>
-  </div>
----
-name: test card with list group, header and footer
-code: |
-  from kutty import html as h
-  from kutty.bootstrap import Card
-
-  card = Card()
-  card.add_header("Featured")
-  card.add(
-    h.ul(class_="list-group list-group-flush")
-      .add(h.li(class_="list-group-item", _content="An item"))
-      .add(h.li(class_="list-group-item", _content="A second item"))
-      .add(h.li(class_="list-group-item", _content="A third item"))
-  )
-  card.add_footer("Card footer")
-
-  result = card.render()
-html: |
-  <div class="card">
-    <div class="card-header">
-      Featured
-    </div>
-    <ul class="list-group list-group-flush">
-      <li class="list-group-item">An item</li>
-      <li class="list-group-item">A second item</li>
-      <li class="list-group-item">A third item</li>
-    </ul>
-    <div class="card-footer">
-      Card footer
-    </div>
-  </div>
----
-name: test card with link in body
-code: |
-  from kutty import Link
-  from kutty.bootstrap import SimpleCard
-
-  card = SimpleCard(title="Card title", subtitle="Card subtitle", text="Card text")
-  card.body << Link("Card link", href="/foo")
-  card.body << Link("Another link", href="/bar")
-
-  result = card.render()
-html: |
-  <div class="card">
-    <div class="card-body">
-      <h5 class="card-title">Card title</h5>
-      <h6 class="card-subtitle text-muted">Card subtitle</h6>
-      <p class="card-text">Card text</p>
-      <a href="/foo" class="card-link">Card link</a>
-      <a href="/bar" class="card-link">Another link</a>
-    </div>
   </div>


### PR DESCRIPTION
Add alert component with support for dismissible and headings. The API has a read-only dismissible attribute while constructing an Alert. Note that there are two TODOs that need to be implemented before this can be called complete:
1. Add JavaScript that makes dismissible work.
2. Add alert-link feature. Links in alert should have this class. Implementing this is put off for later because all elements might not populate their 'children' before rendering. This is true especially for some higher order components.